### PR TITLE
V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ It may seem that way, but seriously this exists as a result of other component s
 libraries such as [`nanomorph`][nanomorph] and [`morphdom`][morph].
 
 For this reason `picocomponent` aims to be more general purpose, leaving DOM diffing strategies up to the consumer,
-while still providing useful features such as `load` / `unload` event listeners by integrating [`on-load`][on-load].
+while still providing useful features such as `connect` / `disconnect` event listeners by integrating [`on-load`][on-load].
 
 ### Have you gone too far?
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,49 @@ var button = new Button()
 document.body.appendChild(button.render('Hello world!'))
 ```
 
+## API
+
+### `PicoComponent.prototype`
+
+`PicoComponent` aims to provide a Class like interface for constructing components.
+
+As a consumer you'll always want to extend the `PicoComponent.prototype` either via ES6 classes:
+
+```js
+class Component extends PicoComponent {
+  // ...
+}
+```
+
+or by extending the base `prototype`:
+
+```js
+function Component () {
+  PicoComponent.call(this)
+}
+
+Button.prototype = Object.create(PicoComponent.prototype)
+```
+
+Instances of `PicoComponent` have the following internal properties:
+
+- `this.el`: Used to manage the DOM node a component is responsible for. Defaults to `null`. See [How do I manage DOM nodes](#how-do-i-manage-dom-nodes) for more info.
+
+### `PicoComponent.prototype.render(...args)`
+
+You'll always want to implement a render function. This forms the public interface for your
+component, and will generally leverage some templating library to manage rendering and updating
+your component. Your `render` method should always return DOM nodes.
+
+### `PicoComponent.prototype.connect()`
+
+When assigned, the `connect` handler will be called once your component has been inserted into the DOM.
+
+### `PicoComponent.prototype.disconnect()`
+
+When assigned, the `disconnect` handler will be called once your component has been removed
+from the DOM.
+
 ## FAQ
 
 ### Is this a joke?
@@ -36,11 +79,29 @@ It may seem that way, but seriously this exists as a result of other component s
 libraries such as [`nanomorph`][nanomorph] and [`morphdom`][morph].
 
 For this reason `picocomponent` aims to be more general purpose, leaving DOM diffing strategies up to the consumer,
-while still providing useful features such as `connect` / `disconnect` event listeners by integrating [`on-load`][on-load].
+while still providing useful features such as `connect`/`disconnect` event listeners by integrating [`on-load`][on-load].
+
+### How do I manage DOM nodes
+
+As a matter of convention `PicoComponent` implements a custom getter/setter used for managing
+the DOM node your component is responsible for.
+
+When assigning a DOM node to your `PicoComponent` instance eg:
+
+```js
+class Button extends PicoComponent {
+  constructor () {
+    super()
+    this.el = document.createElement('button')
+  }
+}
+```
+
+`PicoComponent` will ensure all appropriate lifecycle hooks are correctly assigned.
 
 ### Have you gone too far?
 
-Probably.
+Eh.
 
 ## See also:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ function Button () {
 
 Button.prototype = Object.create(PicoComponent.prototype)
 
-Button.prototype._render = function render (text) {
+Button.prototype.render = function render (text) {
   this.el.innerText = text
   return this.el
 }
@@ -36,7 +36,7 @@ It may seem that way, but seriously this exists as a result of other component s
 libraries such as [`nanomorph`][nanomorph] and [`morphdom`][morph].
 
 For this reason `picocomponent` aims to be more general purpose, leaving DOM diffing strategies up to the consumer,
-while still providing useful features such as `update` hooks, and `load` / `unload` event listeners by integrating [`on-load`][on-load].
+while still providing useful features such as `load` / `unload` event listeners by integrating [`on-load`][on-load].
 
 ### Have you gone too far?
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,9 @@ var hasWindow = typeof window !== 'undefined'
 function PicoComponent () {
   var self = this
   var element = null
-  var loaded = false
+  var connected = false
+  var connectCallback = this.connect
+  var disconnectCallback = this.disconnect
 
   Object.defineProperty(this, 'el', {
     get: function () {
@@ -12,24 +14,24 @@ function PicoComponent () {
     },
     set: function (newElement) {
       element = newElement
-      if (hasWindow && !loaded && (this.load || this.unload)) {
-        onload(element, load, unload, this)
+      if (hasWindow && !connected && (connectCallback || disconnectCallback)) {
+        onload(element, connect, disconnect, this)
       }
     }
   })
 
-  function load (el) {
-    loaded = true
-    self.load && window.requestAnimationFrame(function () {
-      self.load(el)
-    })
+  function connect () {
+    connected = true
+    if (connectCallback) {
+      window.requestAnimationFrame(connectCallback.bind(self))
+    }
   }
 
-  function unload (el) {
-    loaded = false
-    self.unload && window.requestAnimationFrame(function () {
-      self.unload(el)
-    })
+  function disconnect () {
+    connected = false
+    if (disconnectCallback) {
+      window.requestAnimationFrame(disconnectCallback.bind(self))
+    }
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,52 +1,40 @@
 var onload = require('on-load')
+var hasWindow = typeof window !== 'undefined'
 
 function PicoComponent () {
-  this._hasWindow = typeof window !== 'undefined'
-  this._loaded = false
-  this._element = null
+  var self = this
+  var element = null
+  var loaded = false
+
+  Object.defineProperty(this, 'el', {
+    get: function () {
+      return element
+    },
+    set: function (newElement) {
+      element = newElement
+      if (hasWindow && !loaded && (this.load || this.unload)) {
+        onload(element, load, unload, this)
+      }
+    }
+  })
+
+  function load (el) {
+    loaded = true
+    self.load && window.requestAnimationFrame(function () {
+      self.load(el)
+    })
+  }
+
+  function unload (el) {
+    loaded = false
+    self.unload && window.requestAnimationFrame(function () {
+      self.unload(el)
+    })
+  }
 }
 
 PicoComponent.prototype.render = function render () {
-  var self = this
-
-  if (
-    this._element &&
-    (this._update &&
-    !this._update.apply(this, arguments))
-  ) {
-    return this._element
-  }
-
-  this._element = this._render.apply(this, arguments)
-
-  if (
-    this._hasWindow &&
-    this._loaded === false &&
-    (this._load || this._unload)
-  ) {
-    return onload(
-      this._element,
-      function load (el) {
-        self._loaded = true
-        self._load && window.requestAnimationFrame(function () {
-          self._load(el)
-        })
-      },
-      function unload (el) {
-        self._loaded = false
-        self._unload && window.requestAnimationFrame(function () {
-          self._unload(el)
-        })
-      },
-      this
-    )
-  }
-
-  return this._element
-}
-
-PicoComponent.prototype._render = function _render () {
-  throw new Error('picocomponent: _render should be implemented!')
+  throw new Error('picocomponent: render should be implemented!')
 }
 
 module.exports = PicoComponent

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -22,42 +22,42 @@ test('render api', function (t) {
   t.equal(el.innerText, 'testing', 'content updated')
 })
 
-test('load api', function (t) {
+test('connect api', function (t) {
   t.plan(1)
 
-  function Load () {
+  function Connect () {
     Test.call(this)
   }
 
-  Load.prototype = Object.create(Test.prototype)
+  Connect.prototype = Object.create(Test.prototype)
 
-  Load.prototype.load = function () {
-    t.ok(true, 'load called')
+  Connect.prototype.connect = function () {
+    t.ok(true, 'connect called')
   }
 
-  var c = new Load()
+  var c = new Connect()
   var el = c.render('test')
 
-  document.body.appendChild(el) // trigger load
+  document.body.appendChild(el) // trigger connect callback
 })
 
-test('unload api', function (t) {
+test('disconnect api', function (t) {
   t.plan(1)
 
-  function Unload () {
+  function Disconnect () {
     Test.call(this)
   }
 
-  Unload.prototype = Object.create(Test.prototype)
+  Disconnect.prototype = Object.create(Test.prototype)
 
-  Unload.prototype.unload = function () {
-    t.ok(true, 'unload called')
+  Disconnect.prototype.disconnect = function () {
+    t.ok(true, 'disconnect called')
   }
 
-  var c = new Unload()
+  var c = new Disconnect()
   var el = c.render('test')
 
-  document.body.appendChild(el) // trigger load
+  document.body.appendChild(el) // trigger connect
 
-  document.body.innerHTML = '' // trigger unload
+  document.body.innerHTML = '' // trigger disconnect
 })

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -2,7 +2,7 @@ var PicoComponent = require('../')
 var Test = require('./component')
 var test = require('tape')
 
-test('notify "_render" requirement', function (t) {
+test('notify "render" requirement', function (t) {
   t.plan(1)
   var c = new PicoComponent()
   t.throws(c.render.bind(c))
@@ -22,28 +22,6 @@ test('render api', function (t) {
   t.equal(el.innerText, 'testing', 'content updated')
 })
 
-test('update api', function (t) {
-  t.plan(2)
-
-  function Update () {
-    Test.call(this)
-  }
-
-  Update.prototype = Object.create(Test.prototype)
-
-  Update.prototype._update = function () {
-    t.ok(true, 'update called')
-    return false
-  }
-
-  var c = new Update()
-  var el = c.render('test')
-
-  el = c.render('testing') // trigger update
-
-  t.equal(el.innerText, 'test', 'content unchanged')
-})
-
 test('load api', function (t) {
   t.plan(1)
 
@@ -53,7 +31,7 @@ test('load api', function (t) {
 
   Load.prototype = Object.create(Test.prototype)
 
-  Load.prototype._load = function () {
+  Load.prototype.load = function () {
     t.ok(true, 'load called')
   }
 
@@ -72,7 +50,7 @@ test('unload api', function (t) {
 
   Unload.prototype = Object.create(Test.prototype)
 
-  Unload.prototype._unload = function () {
+  Unload.prototype.unload = function () {
     t.ok(true, 'unload called')
   }
 

--- a/tests/component.js
+++ b/tests/component.js
@@ -7,8 +7,9 @@ function Test (opts) {
 
 Test.prototype = Object.create(PicoComponent.prototype)
 
-Test.prototype._render = function render (text) {
-  return html`<div>${text}</div>`
+Test.prototype.render = function render (text) {
+  this.el = html`<div>${text}</div>`
+  return this.el
 }
 
 module.exports = Test

--- a/tests/server.js
+++ b/tests/server.js
@@ -17,12 +17,12 @@ test('basic server', function (t) {
 
   Server.prototype = Object.create(Test.prototype)
 
-  Server.prototype.load = function () {
-    t.fail('load called')
+  Server.prototype.connect = function () {
+    t.fail('connect called')
   }
 
-  Server.prototype.unload = function () {
-    t.fail('unload called')
+  Server.prototype.disconnect = function () {
+    t.fail('disconnect called')
   }
 
   var c = new Server()

--- a/tests/server.js
+++ b/tests/server.js
@@ -2,14 +2,14 @@ var PicoComponent = require('../')
 var Test = require('./component')
 var test = require('tape')
 
-test('notify "_render" requirement', function (t) {
+test('notify "render" requirement', function (t) {
   t.plan(1)
   var c = new PicoComponent()
   t.throws(c.render.bind(c))
 })
 
 test('basic server', function (t) {
-  t.plan(4)
+  t.plan(2)
 
   function Server () {
     Test.call(this)
@@ -17,22 +17,16 @@ test('basic server', function (t) {
 
   Server.prototype = Object.create(Test.prototype)
 
-  Server.prototype._load = function () {
+  Server.prototype.load = function () {
     t.fail('load called')
   }
 
-  Server.prototype._unload = function () {
+  Server.prototype.unload = function () {
     t.fail('unload called')
-  }
-
-  Server.prototype._update = function () {
-    t.ok(true, 'update called')
-    return true
   }
 
   var c = new Server()
 
-  t.equal(c._hasWindow, false, 'no window')
   t.equal(c.render().toString(), '<div></div>', 'renders template')
   t.equal(c.render('test').toString(), '<div>test</div>', 'updates template')
 })


### PR DESCRIPTION
New in v2 🎉 

- Departure from an API based around configuring "private" methods, eg. `_render` is now `render`.
- Removal of `_hasWindow` property.
- Removal of `_update` handler.
- Renamed `_load`/`_unload` handlers to `connect`/`disconnect` to align our terminology with the `CustomElements` spec.
- Custom getter/setter for `PicoComponent.el` to contain logic for `connect`/`disconnect` handlers, and also to provide a public interface for retrieving the rendered component node.


Todo:
 - [x] Add additional documentation